### PR TITLE
Disable nuget package generation on build

### DIFF
--- a/StoreLib/StoreLib.csproj
+++ b/StoreLib/StoreLib.csproj
@@ -6,7 +6,7 @@
     <Version>1.2.1</Version>
     <Authors>TitleOS</Authors>
     <Company>N/A</Company>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Description>Storelib is a DotNet library that provides APIs to interact with the various Microsoft Store endpoints.</Description>
     <Copyright>TitleOS</Copyright>
     <PackageProjectUrl>https://github.com/StoreDev/StoreLib</PackageProjectUrl>


### PR DESCRIPTION
Disables the NuGet package generation on build for StoreLib as its not needed and breaks github workflows sporadically.